### PR TITLE
PICO: use version 4.2.0, not 3.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ C3 supports a simple way to organize words using lexicons.
   - NAME_LEN:   17
 - For the RPI Pico:
   - Use the arduino-pico from earlephilhower (https://github.com/earlephilhower/arduino-pico)
+  - The version must be 4.2.0 or later. Versions older than 4.0.0 do not support boards using
+    the RP2350 microcontroller.
   - Use `#define _PicoFS_` to include support for LittleFS
 - For the Teensy-4.x:
   - Use `#define _TeensyFS_` to include support for LittleFS

--- a/fs-pico.cpp
+++ b/fs-pico.cpp
@@ -15,8 +15,8 @@ void fileInit() {
 	printString("\r\nLittleFS: begin ...");
 	myFS.begin();
 	printString("done.");
-    FSInfo64 fsinfo;
-    LittleFS.info64(fsinfo);
+    FSInfo fsinfo;
+    LittleFS.info(fsinfo);
 	printString("\r\nLittleFS: initialized");
 	//printStringF("\r\nBytes total: %llu, used: %llu", fsinfo.totalBytes, fsinfo.usedBytes);
 	input_fp = input_sp = 0;


### PR DESCRIPTION
Fix for issue #61 

The FSInfo64 worked in version 3.9.4, but version 4.2.0 provides FSInfo, not FSInfo64